### PR TITLE
Resource API v1.2.4 CPI for DCC Changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ WORKDIR /usr/src/app
 ENV NPM_VERSION=11.7.0
 RUN npm install -g npm@${NPM_VERSION}
 RUN npm install -g glob@11.1.0
-RUN npm install -g tar@7.5.3
+RUN npm install -g tar@7.5.4
 
 # Download dependencies as a separate step to take advantage of Docker's caching.
 # Leverage a cache mount to /root/.npm to speed up subsequent builds.

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ WORKDIR /usr/src/app
 ENV NPM_VERSION=11.7.0
 RUN npm install -g npm@${NPM_VERSION}
 RUN npm install -g glob@11.1.0
-RUN npm install -g tar@7.5.2
+RUN npm install -g tar@7.5.3
 
 # Download dependencies as a separate step to take advantage of Docker's caching.
 # Leverage a cache mount to /root/.npm to speed up subsequent builds.

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ FROM node:25.3.0-alpine3.23 AS fnl_base_image
 # ENV federation_apis=${federation_apis}
 
 # Use production node environment by default.
-ENV NODE_ENV production
+ENV NODE_ENV=production
 ENV NEW_RELIC_NO_CONFIG_FILE=true
 ENV NEW_RELIC_DISTRIBUTED_TRACING_ENABLED=true
 ENV NEW_RELIC_LOG=stdout

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@
 # If you need more help, visit the Dockerfile reference guide at
 # https://docs.docker.com/engine/reference/builder/
 
-#ARG NODE_VERSION=25.2.1
+#ARG NODE_VERSION=25.3.0
 
 #FROM node:${NODE_VERSION}-alpine3.23
-FROM node:25.2.1-alpine3.23 AS fnl_base_image
+FROM node:25.3.0-alpine3.23 AS fnl_base_image
 
 ## Update Alpine option
 #RUN apk update

--- a/app/utils/cpiUtils.js
+++ b/app/utils/cpiUtils.js
@@ -38,6 +38,19 @@ const cpiUrl = process.env.cpi_url;
 
 axios.defaults.timeout = 15000;
 
+// federationDomainNamespace provided by serverForApi.js
+let federationDomainNamespace = [];
+function setFederationDomainNamespace(arr) {
+  if (Array.isArray(arr)) {
+    federationDomainNamespace = arr;
+    let outputMsg = {level: "info", server: "resource", note: "cpiUtils federationDomainNamespace set", value: federationDomainNamespace};
+    console.info(JSON.stringify(outputMsg));
+  } else {
+    let outputMsg = {level: "error", server: "resource", note: "cpiUtils setFederationDomainNamespace expects an array"};
+    console.error(JSON.stringify(outputMsg));
+  }
+}
+ 
 // console.debug("debug", JSON.stringify(optionsToken));
 //strCpiMock is mock CPI response data 
 const strCpiMock = JSON.stringify({supplementary_domains: [], participant_ids: 
@@ -152,11 +165,26 @@ function extractIdFromData(data) {
       if (item.data && Array.isArray(item.data)) {
         // Iterate over the "data" array to find "id" and "metadata.depositions" objects
         item.data.forEach(dataItem => {
-          if ((dataItem.id) && dataItem.kind === 'Participant') {
-            // Create a new object with the id and merge it with "depositions" from metadata
-            let extractedData = {source: item.source, name: dataItem.id.name};
-            result.push(extractedData); // Push the merged object into the result array
+          if ((dataItem.id) && (dataItem.id.name)) {
+            if (dataItem.kind === 'Participant') {//send only this kind to CPI 
+              // Create a new object with the id
+              let extractedData = null; // only push when extractedData was successfully created
+              // If federationDomainNamespace is not provided or does not include item.source,
+              // keep the source as CPI domain. 
+              if (!federationDomainNamespace.includes(item.source)) {
+                extractedData = {source: item.source, name: dataItem.id.name};
+                result.push(extractedData); // Push the merged object into the result array
+              } // Otherwise use namespaceas CPI domain if the data is there.
+              else if ((dataItem.id.namespace) && (dataItem.id.namespace.name)) {
+                extractedData = {source: dataItem.id.namespace.name, name: dataItem.id.name};
+                result.push(extractedData); // Push the merged object into the result array
+              }
+           }
           }
+          else {// log an error if subject.data.id format is not as expected
+            let outputMsgRespId = {level: "error", server: "resource", note: "parseSourceSubjectIds: participant id or name is missing in subject data " + item.source};
+            console.error(JSON.stringify(outputMsgRespId));
+           }
         });
       }
     });
@@ -213,7 +241,6 @@ function generateCpiRequestBody(data) {
   //console.debug("debug", "generateCpiBody result\n", loadData);
   return loadData;
 };
-
 //apiToCpi returns JSON response string Promise
 async function apiToCpi(apiSubjectData) {
   if (! isCpiConfigured()) {
@@ -334,6 +361,7 @@ module.exports = {
     parseSubjectIds,
     generateCpiRequestBody,
     isCpiConfigured,
+    setFederationDomainNamespace,
     cpiInit,
     apiToCpi
 }

--- a/app/utils/cpiUtils.js
+++ b/app/utils/cpiUtils.js
@@ -259,7 +259,7 @@ async function apiToCpi(apiSubjectData) {
         console.info(JSON.stringify(outputMsgResp));
         // start CPI request workflow
         //console.info("info IDs sent to CPI", JSON.stringify(cpiIds));
-        outputMsgResp = {level: "info", ids: JSON.stringify(cpiIds)};
+        outputMsgResp = {level: "info", ids: cpiIds, server: "resource", endpoint: "subject-mapping", note: "API Participant IDs for CPI"};
         console.info(JSON.stringify(outputMsgResp));
         var cpiResponse = await getCPIRequest(currToken, cpiIds);
         //var cpiResponse = await getCPIRequest(currToken, requestBodyCpi);//this is a sample data to send to CPI

--- a/compose.yaml
+++ b/compose.yaml
@@ -13,6 +13,7 @@ services:
       cpi_client_id: ${cpi_client_id}
       cpi_url: ${cpi_url}
       federation_sources: ${federation_sources}
+      federation_domain_namespace: ${federation_domain_namespace}
       server_host: "0.0.0.0"
     ports:
       - "3000:3000"

--- a/compose.yaml
+++ b/compose.yaml
@@ -14,6 +14,7 @@ services:
       cpi_url: ${cpi_url}
       federation_sources: ${federation_sources}
       federation_domain_namespace: ${federation_domain_namespace}
+      USER_AGENT: ${USER_AGENT}
       server_host: "0.0.0.0"
     ports:
       - "3000:3000"

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ccdi-federation-api-aggregation",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -1918,9 +1918,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1469,9 +1469,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ccdi-federation-api-aggregation",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ccdi-federation-api-aggregation",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.13.2",
@@ -15,6 +15,7 @@
         "newrelic": "latest",
         "process": "^0.11.10",
         "psl": "^1.15.0",
+        "qs": "^6.14.1",
         "tar-fs": "^3.1.1"
       },
       "devDependencies": {},
@@ -1937,9 +1938,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1489,9 +1489,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "overrides": {
     "brace-expansion": "^1.1.12",
     "form-data": "^4.0.5",
-    "glob": "^11.1.0"
+    "glob": "^11.1.0",
+    "lodash": "^4.17.23"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccdi-federation-api-aggregation",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "CCDI Data Federation platform API aggregation level implementation.",
   "main": "serverForApi.js",
   "scripts": {
@@ -39,7 +39,8 @@
     "newrelic": "latest",
     "process": "^0.11.10",
     "psl": "^1.15.0",
-    "tar-fs": "^3.1.1"
+    "tar-fs": "^3.1.1",
+    "qs":"^6.14.1"
   },
   "devDependencies": {
   },

--- a/serverForApi.js
+++ b/serverForApi.js
@@ -12,6 +12,7 @@ const cpiUtils = require("./app/utils/cpiUtils");
 const strCpiRequest = "subject-mapping";
 const strSubjectRequest = "subject";
 const strSubjectDiagnosisRequest = "subject-diagnosis";
+const pkg = require('./package.json');
 
 //certificates are not used, defined by setting rejectUnauthorized
 // const caTreehouse = [fs.readFileSync("./treehouse-cer.pem")];
@@ -27,11 +28,18 @@ const optionsGeneral = {
   //path: urlPath,
   method: 'GET',
   headers: {
-    Accept: 'application/json',
+    Accept: 'application/json'
   },
   timeout: 12000,
   rejectUnauthorized: false
 };
+
+// Build a default User-Agent identifying this service and runtime.
+// Allow overriding with the USER_AGENT env var when necessary.
+const defaultUserAgent = `Federation Resource API/${pkg.version} node/${process.version} (${process.platform})`;
+optionsGeneral.headers['User-Agent'] = process.env.USER_AGENT || defaultUserAgent;
+let infoMsgUA = {level: "info", server: "resource", note: "User-Agent set", userAgent: optionsGeneral.headers['User-Agent']};
+console.info(JSON.stringify(infoMsgUA));
 
 // hosts registration is static for now
 // host are defined in env var federation_apis
@@ -39,12 +47,21 @@ const optionsGeneral = {
 // expected are hosts from registered servers only
 var apiHosts = process.env.federation_apis.split(",");
 var apiSources = [];
+var federationDomainNamespace = [];
 if (process.env.federation_sources) {
   apiSources = process.env.federation_sources.split(",");
 }
 else {
   //console.error("error", "env federation_sources is not defined");
   let infoMsg0 = {level:"error", server: "resource", note: "env federation_sources is not defined"};
+  console.error(JSON.stringify(infoMsg0))
+};
+if (process.env.federation_domain_namespace) {
+  federationDomainNamespace = process.env.federation_domain_namespace.split(",");
+}
+else {
+  //console.error("error", "env federation_sources is not defined");
+  let infoMsg0 = {level:"error", server: "resource", note: "env federation_domain_namespace is not defined"};
   console.error(JSON.stringify(infoMsg0))
 };
 
@@ -78,6 +95,9 @@ console.info(JSON.stringify(infoMsg));
 var apiHostSourceMap = urlUtils.mapHostToSource(apiDomains, apiSources);
 
 const startApiUrl = "/api/v";//we do not validate the version
+
+// provide federationDomainNamespace to cpiUtils
+cpiUtils.setFederationDomainNamespace(federationDomainNamespace);
 
 //CPI configuration
 cpiUtils.cpiInit();

--- a/serverForApi.js
+++ b/serverForApi.js
@@ -60,7 +60,6 @@ if (process.env.federation_domain_namespace) {
   federationDomainNamespace = process.env.federation_domain_namespace.split(",");
 }
 else {
-  //console.error("error", "env federation_sources is not defined");
   let infoMsg0 = {level:"error", server: "resource", note: "env federation_domain_namespace is not defined"};
   console.error(JSON.stringify(infoMsg0))
 };


### PR DESCRIPTION
API to CPI communication implementation extended to allow using the "namespace" subject ID value as the CPI domain. The previous version used the current "source" attribute.
FEDERATION-356 subject-mapping endpoint to accommodate namespace
Other issues addressed:
FEDERATION-435	CVE-2025-15284 - qs NodeJS package	
FEDERATION-465	NSWG-COR-163 - nodejs/node Node.js bugs
FEDERATION-466	CVE-2026-23745 - tar NodeJS package
FEDERATION-467	CVE-2026-23950 - tar NodeJS package
FEDERATION-468	CVE-2025-13465 - lodash NodeJS package
