### PR TITLE
Resource API v1.2.5 Introduce Request Timeout Configuration and Address Security

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,9 @@ FROM node:25.6.0-alpine3.23 AS fnl_base_image
 ## Update Alpine busybox
 # RUN apk update && apk upgrade busybox
 
+## Update Alpine openssl
+RUN apk update && apk upgrade openssl
+
 # ENV federation_apis=${federation_apis}
 
 # Use production node environment by default.

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@
 # If you need more help, visit the Dockerfile reference guide at
 # https://docs.docker.com/engine/reference/builder/
 
-#ARG NODE_VERSION=25.3.0
+#ARG NODE_VERSION=25.6.0
 
 #FROM node:${NODE_VERSION}-alpine3.23
-FROM node:25.3.0-alpine3.23 AS fnl_base_image
+FROM node:25.6.0-alpine3.23 AS fnl_base_image
 
 ## Update Alpine option
 #RUN apk update
@@ -23,10 +23,10 @@ ENV NEW_RELIC_DISTRIBUTED_TRACING_ENABLED=true
 ENV NEW_RELIC_LOG=stdout
 
 WORKDIR /usr/src/app
-ENV NPM_VERSION=11.7.0
+ENV NPM_VERSION=11.8.0
 RUN npm install -g npm@${NPM_VERSION}
 RUN npm install -g glob@11.1.0
-RUN npm install -g tar@7.5.4
+RUN npm install -g tar@7.5.7
 
 # Download dependencies as a separate step to take advantage of Docker's caching.
 # Leverage a cache mount to /root/.npm to speed up subsequent builds.

--- a/app/utils/cpiUtils.js
+++ b/app/utils/cpiUtils.js
@@ -333,7 +333,7 @@ async function getCPIRequest(accessToken, requestBody) {
  
         const response = await axios.get(cpiUrl, {
             headers,
-            timeout: 15000,
+            timeout: 60000,
             data: requestBody, // axios GET doesn't support json, so we use object instead
             httpsAgent: new (require('https').Agent)({ rejectUnauthorized: false })
         });

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ccdi-federation-api-aggregation",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ccdi-federation-api-aggregation",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ccdi-federation-api-aggregation",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.13.2",
@@ -20,8 +20,8 @@
       },
       "devDependencies": {},
       "engines": {
-        "node": ">=25.2.1",
-        "npm": ">=11.6.0"
+        "node": ">=25.5.0",
+        "npm": ">=11.8.0"
       }
     },
     "node_modules/@colors/colors": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccdi-federation-api-aggregation",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "CCDI Data Federation platform API aggregation level implementation.",
   "main": "serverForApi.js",
   "scripts": {
@@ -9,8 +9,8 @@
     "lint": "eslint ./app/**/*.* --ext .js"
   },
   "engines": {
-    "node": ">=25.2.1",
-    "npm": ">=11.6.0"
+    "node": ">=25.5.0",
+    "npm": ">=11.8.0"
   },
   "repository": {
     "type": "git",

--- a/serverForApi.js
+++ b/serverForApi.js
@@ -5,7 +5,7 @@ const newrelic = require('newrelic');
 const http = require("http");
 const https = require("https");
 const process = require("process");
-const url = require('url');
+//const url = require('url');
 const urlUtils = require("./app/utils/urlUtils");
 const specUtils = require("./app/utils/specUtils");
 const cpiUtils = require("./app/utils/cpiUtils");
@@ -30,7 +30,7 @@ const optionsGeneral = {
   headers: {
     Accept: 'application/json'
   },
-  timeout: 12000,
+  timeout: 120000,//120 seconds default timeout for response from federation nodes; used in getresultHttp
   rejectUnauthorized: false
 };
 
@@ -40,6 +40,28 @@ const defaultUserAgent = `Federation Resource API/${pkg.version} node/${process.
 optionsGeneral.headers['User-Agent'] = process.env.USER_AGENT || defaultUserAgent;
 let infoMsgUA = {level: "info", server: "resource", note: "User-Agent set", userAgent: optionsGeneral.headers['User-Agent']};
 console.info(JSON.stringify(infoMsgUA));
+
+// Set timeout from environment variable federation_request_timeout (given in seconds)
+var requestTimeoutEnv = process.env.federation_request_timeout;
+if (requestTimeoutEnv) {
+  let infoMsg = {level: "info", server: "resource", note: "federation_request_timeout environment value is received: " + requestTimeoutEnv};
+  console.info(JSON.stringify(infoMsg));
+  const trimmed = ('' + requestTimeoutEnv).trim();
+  const parsed = Number(trimmed);
+  if (Number.isInteger(parsed) && parsed > 0) {
+    optionsGeneral.timeout = parsed*1000; // change the value to milliseconds in options
+    let infoMsg1 = {level: "info", server: "resource", note: "federation request timeout set in milliseconds to " + optionsGeneral.timeout};
+    console.info(JSON.stringify(infoMsg1));
+  }
+  else {
+    let errMsg = {level: "error", server: "resource", note: "invalid federation_request_timeout; must be a positive integer (seconds) " + requestTimeoutEnv};
+    console.error(JSON.stringify(errMsg));
+  }
+}
+else {
+    let errMsg = {level: "error", server: "resource", note: "federation_request_timeout environment not provided, using default 120 seconds"};
+    console.error(JSON.stringify(errMsg));
+}
 
 // hosts registration is static for now
 // host are defined in env var federation_apis


### PR DESCRIPTION
Make Federation servers requests timeouts configurable and default to 120 seconds.
Address security issues.
FEDERATION-487 Implement configurable timeout for all participating servers
FEDERATION-488 Update API environment to add federation_request_timeout variable
FEDERATION-485 CVE-2025-15467 - openssl
FEDERATION-489 CVE-2026-24842 - tar NodeJS package
